### PR TITLE
Provide DMS from phys_control

### DIFF
--- a/src/control/camsrfexch.F90
+++ b/src/control/camsrfexch.F90
@@ -510,7 +510,11 @@ subroutine cam_export(state,cam_out,pbuf)
       ! Direction of bottom level wind
       ubot = state%u(i,pver)
       vbot = state%v(i,pver)
-      cam_out%wind_dir(i) = atan2(vbot,ubot)
+      if ((ubot == 0.0_r8) .and. (vbot == 0.0_r8)) then
+         cam_out%wind_dir(i) = 0.0_r8 ! Default to U for zero wind
+      else
+         cam_out%wind_dir(i) = atan2(vbot,ubot)
+      end if
    end do
    do m = 1, pcnst
      do i = 1, ncol

--- a/src/physics/cam/phys_control.F90
+++ b/src/physics/cam/phys_control.F90
@@ -10,10 +10,11 @@ module phys_control
 !                             Add vars to indicate physics version and chemistry type.
 !-----------------------------------------------------------------------
 
-use spmd_utils,     only: masterproc
-use cam_logfile,    only: iulog
-use cam_abortutils, only: endrun
-use shr_kind_mod,   only: r8 => shr_kind_r8, cl=>shr_kind_cl
+use spmd_utils,        only: masterproc
+use cam_logfile,       only: iulog
+use cam_abortutils,    only: endrun
+use shr_kind_mod,      only: r8 => shr_kind_r8, cl=>shr_kind_cl
+use atm_import_export, only: drv_dms_from_ocn => dms_from_ocn
 
 implicit none
 private
@@ -56,7 +57,7 @@ logical           :: history_vdiag        = .false.    ! output the variables us
 logical           :: history_aerosol      = .false.    ! output the MAM aerosol variables and tendencies
 logical           :: history_aero_optics  = .false.    ! output the aerosol
 logical           :: history_eddy         = .false.    ! output the eddy variables
-logical           :: history_budget       = .false.    ! output tendencies and state variables for T, water vapor, 
+logical           :: history_budget       = .false.    ! output tendencies and state variables for T, water vapor,
                                                        ! cloud ice and cloud liquid budgets
 logical           :: convproc_do_aer      = .false.    ! switch for new convective scavenging treatment for modal aerosols
 
@@ -104,6 +105,9 @@ logical, public, protected :: fv_am_correction = .false.
 
 ! Option for Harmonized Emissions Component (HEMCO)
 logical, public, protected :: use_hemco = .false.
+
+! Take DMS from ocean?
+logical, public, protected :: dms_from_ocn = .false.
 
 ! CAM snapshot before/after file numbers and control
 character(len=32) :: cam_take_snapshot_before = ''  ! Physics routine to take a snopshot "before"
@@ -276,6 +280,9 @@ subroutine phys_ctl_readnl(nlfile)
 
    ! prog_modal_aero determines whether prognostic modal aerosols are present in the run.
    prog_modal_aero = index(cam_chempkg,'_mam')>0
+
+   ! Set this from the driver namelist (always read first)
+   dms_from_ocn = drv_dms_from_ocn
 
 end subroutine phys_ctl_readnl
 


### PR DESCRIPTION
Special case for atan2
Provide dms_from_ocn from phys_control instead of coupling layer.